### PR TITLE
add example prototype for check

### DIFF
--- a/.github/LICENSE-SYSINFO
+++ b/.github/LICENSE-SYSINFO
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright © 2016 Zlatko Čalušić
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmd/compspec/check/check.go
+++ b/cmd/compspec/check/check.go
@@ -1,0 +1,66 @@
+package check
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/supercontainers/compspec-go/pkg/oras"
+	"github.com/supercontainers/compspec-go/pkg/types"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	defaultMediaType = "application/org.supercontainers.compspec"
+)
+
+// loadManifest loads the manifest into a ManifestList
+func loadManifest(filename string) (*types.ManifestList, error) {
+	m := types.ManifestList{}
+	yamlFile, err := os.ReadFile(filename)
+	if err != nil {
+		return &m, err
+	}
+
+	err = yaml.Unmarshal(yamlFile, &m)
+	if err != nil {
+		return &m, err
+	}
+	return &m, nil
+}
+
+// Run will check a manifest list of artifacts against a host machine
+// For now, the host machine parameters will be provided as flags
+func Run(manifestFile string, hostFields []string, mediaType string) error {
+
+	// Default media type if one not provided
+	if mediaType == "" {
+		mediaType = defaultMediaType
+	}
+
+	// Cut out early if a spec not provided
+	if manifestFile == "" {
+		return fmt.Errorf("A manifest file input -i/--input is required")
+	}
+	manifestList, err := loadManifest(manifestFile)
+	if err != nil {
+		return err
+	}
+	fmt.Println(manifestList)
+
+	// Load the compatibility specs into a lookup by image
+	// This assumes we allow one image per compability spec, not sure
+	// if there is a use case to have an image twice with two (sounds weird)
+	lookup := map[string]types.CompatibilityRequest{}
+	for _, item := range manifestList.Images {
+		compspec, err := oras.LoadArtifact(item.Artifact, mediaType)
+		if err != nil {
+			fmt.Printf("warning, there was an issue loading the artifact for %s, skipping\n", item.Name)
+		}
+		lookup[item.Name] = compspec
+	}
+
+	// TODO we will take this set of requests, load them into a graph,
+	// and then query the graph based on user preferences (the host fields)
+	// that are provided that describe the host we want to match compatibility with
+	return nil
+}

--- a/cmd/compspec/compspec.go
+++ b/cmd/compspec/compspec.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/akamensky/argparse"
+	"github.com/supercontainers/compspec-go/cmd/compspec/check"
 	"github.com/supercontainers/compspec-go/cmd/compspec/create"
 	"github.com/supercontainers/compspec-go/cmd/compspec/extract"
 	"github.com/supercontainers/compspec-go/cmd/compspec/list"
@@ -32,6 +33,7 @@ func main() {
 	extractCmd := parser.NewCommand("extract", "Run one or more extractors")
 	listCmd := parser.NewCommand("list", "List plugins and known sections")
 	createCmd := parser.NewCommand("create", "Create a compatibility artifact for the current host according to a definition")
+	checkCmd := parser.NewCommand("check", "Check a manifest of container images / artifact pairs against a set of host fields")
 
 	// Shared arguments (likely this will break into check and extract, shared for now)
 	pluginNames := parser.StringList("n", "name", &argparse.Options{Help: "One or more specific plugins to target names"})
@@ -39,10 +41,15 @@ func main() {
 	// Extract arguments
 	filename := extractCmd.String("o", "out", &argparse.Options{Help: "Save extraction to json file"})
 
+	// Check arguments
+	hostFields := checkCmd.StringList("a", "append", &argparse.Options{Help: "Append one or more host fields to include in the check"})
+	manifestFile := checkCmd.String("i", "in", &argparse.Options{Required: true, Help: "Input manifest list yaml that contains pairs of images and artifacts"})
+
 	// Create arguments
-	options := parser.StringList("a", "append", &argparse.Options{Help: "One or more custom metadata fields to append"})
+	options := parser.StringList("a", "append", &argparse.Options{Help: "Append one or more custom metadata fields to append"})
 	specname := createCmd.String("i", "in", &argparse.Options{Required: true, Help: "Input yaml that contains spec for creation"})
 	specfile := createCmd.String("o", "out", &argparse.Options{Help: "Save compatibility json artifact to this file"})
+	mediaType := createCmd.String("m", "media-type", &argparse.Options{Help: "The expected media-type for the compatibility artifact"})
 
 	// Now parse the arguments
 	err := parser.Parse(os.Args)
@@ -62,6 +69,12 @@ func main() {
 		if err != nil {
 			log.Fatal(err.Error())
 		}
+	} else if checkCmd.Happened() {
+		err := check.Run(*manifestFile, *hostFields, *mediaType)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+
 	} else if listCmd.Happened() {
 		err := list.Run(*pluginNames)
 		if err != nil {

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,4 +9,5 @@ This is early documentation that will be converted eventually to something prett
 ## Thanks and Previous Art
 
 - I learned about kernel parsing from [mfranczy/compat](https://github.com/mfranczy/compat)
+- The graph design is based on the (now archived) [kraph](https://github.com/milosgajdos/kraph), released under Apache-2
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -136,7 +136,81 @@ For now we will manually remember the pairing, at least until the compatibility 
 
 Check is the command you would use to check a potential host against one or more existing artifacts.
 For a small experiment of using create against a set of containers and then testing how to do a check, we are going to place content
-in [examples/check-lammps](examples/check-lammps).
+in [examples/check-lammps](examples/check-lammps). As an example, we might use the manifest in that directory to run a check.
+Note that since most use cases aren't checking the images in the manifest list against the host running the command, we instead
+provide the parameters about the expected runtime host to them.
+
+```bash
+./bin/compspec check -i ./examples/check-lammps/manifest.yaml
+```
+
+<details>
+
+<summary>Example check output</summary>
+
+```console
+&{[{ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64 ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64-compspec}]}
+Found digest: sha256:b0382d21a2e734ffd3b39160443384fdd44ee7b38e99197f1c832dd73216af2d for intel-mpi-rocky-9-amd64-compspec
+{
+  "version": "0.0.0",
+  "kind": "CompatibilitySpec",
+  "metadata": {
+    "name": "lammps-prototype",
+    "jsonSchema": "https://raw.githubusercontent.com/supercontainers/compspec/main/supercontainers/compspec.json"
+  },
+  "compatibilities": [
+    {
+      "name": "org.supercontainers.mpi",
+      "version": "0.0.0",
+      "annotations": {
+        "implementation": "intel-mpi",
+        "version": "2021.8"
+      }
+    },
+    {
+      "name": "org.supercontainers.os",
+      "version": "0.0.0",
+      "annotations": {
+        "name": "Rocky Linux 9.3 (Blue Onyx)",
+        "release": "9.3",
+        "vendor": "rocky",
+        "version": "9.3"
+      }
+    },
+    {
+      "name": "org.supercontainers.hardware.gpu",
+      "version": "0.0.0",
+      "annotations": {
+        "available": "no"
+      }
+    },
+    {
+      "name": "io.archspec.cpu",
+      "version": "0.0.0",
+      "annotations": {
+        "model": "13th Gen Intel(R) Core(TM) i5-1335U",
+        "target": "amd64",
+        "vendor": "GenuineIntel"
+      }
+    }
+  ]
+}
+{0.0.0 CompatibilitySpec {lammps-prototype https://raw.githubusercontent.com/supercontainers/compspec/main/supercontainers/compspec.json} [{org.supercontainers.mpi 0.0.0 map[implementation:intel-mpi version:2021.8]} {org.supercontainers.os 0.0.0 map[name:Rocky Linux 9.3 (Blue Onyx) release:9.3 vendor:rocky version:9.3]} {org.supercontainers.hardware.gpu 0.0.0 map[available:no]} {io.archspec.cpu 0.0.0 map[model:13th Gen Intel(R) Core(TM) i5-1335U target:amd64 vendor:GenuineIntel]}]}
+```
+
+</details>
+
+Note that if you provide (append) zero host fields with `-a` for each, you will basically get back the listing of ordered images.
+The command logic and (very simple) algortithm works as follows.
+
+1. Read in all entries from the list
+2. Retrieve their artifacts, look for the "application/org.supercontainers.compspec" layer media type to identify it.
+3. Retrieve it (within the application) and parse into the compatibility metadata
+4. Create a flat graph with a node for each image, and annotations as the attributes
+5. Search the graph based on the provided preferences
+
+Note that the current prototype knows how to read in the manifest and print out the json. I am going to play around with graphs (and making a library) soon that we can use here.
+
 
 ## Extract
 

--- a/examples/check-lammps/README.md
+++ b/examples/check-lammps/README.md
@@ -31,7 +31,7 @@ cmd=". /etc/profile && /tmp/data/generate-artifact.sh no /tmp/data/specs/compspe
 docker run -v $PWD:/tmp/data -it ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64 /bin/bash -c "$cmd"
 
 # This generates ./specs/compspec-intel-mpi-rocky-9-amd64.json, let's push to a registry with oras
-oras push ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64-compspec --artifact-type application/org.supercontainers.compspec ./specs/compspec-intel-mpi-rocky-9-amd64.json
+oras push ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64-compspec-test --artifact-type application/org.supercontainers.compspec ./specs/compspec-intel-mpi-rocky-9-amd64.json:application/org.supercontainers.compspec
 ```
 
 Here is how we might see it:

--- a/examples/check-lammps/manifest.yaml
+++ b/examples/check-lammps/manifest.yaml
@@ -1,0 +1,6 @@
+# Check manifest
+# This is an example manifest to manually pair container images with their compatibility artifacts
+# note that the artifact layer type needs to be "application/org.supercontainers.compspec" to be discovered
+images:
+  - name: ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64
+    artifact: ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64-compspec

--- a/examples/generated-compatibility-spec.json
+++ b/examples/generated-compatibility-spec.json
@@ -15,6 +15,16 @@
       }
     },
     {
+      "name": "org.supercontainers.os",
+      "version": "0.0.0",
+      "annotations": {
+        "name": "Ubuntu 22.04.3 LTS",
+        "release": "22.04.3",
+        "vendor": "ubuntu",
+        "version": "22.04"
+      }
+    },
+    {
       "name": "org.supercontainers.hardware.gpu",
       "version": "0.0.0",
       "annotations": {

--- a/go.mod
+++ b/go.mod
@@ -7,14 +7,18 @@ require (
 	github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8
 	github.com/jedib0t/go-pretty/v6 v6.5.3
 	github.com/moby/moby v25.0.0+incompatible
+	github.com/opencontainers/image-spec v1.1.0-rc5
 	golang.org/x/sys v0.16.0
+	oras.land/oras-go/v2 v2.3.1
 	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	golang.org/x/sync v0.4.0 // indirect
 	gotest.tools/v3 v3.5.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,10 @@ github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZ
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/moby/moby v25.0.0+incompatible h1:KIFudkwXNK+kBrnCxWZNwhEf/jJzdjQAP7EF/awywMI=
 github.com/moby/moby v25.0.0+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.1.0-rc5 h1:Ygwkfw9bpDvs+c9E34SdgGOj41dX/cbdlwvlWt0pnFI=
+github.com/opencontainers/image-spec v1.1.0-rc5/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
@@ -24,6 +28,8 @@ github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVs
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
+golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
 golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
@@ -33,5 +39,7 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
 gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
+oras.land/oras-go/v2 v2.3.1 h1:lUC6q8RkeRReANEERLfH86iwGn55lbSWP20egdFHVec=
+oras.land/oras-go/v2 v2.3.1/go.mod h1:5AQXVEu1X/FKp1F9DMOb5ZItZBOa0y5dha0yCm4NR9c=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -1,0 +1,4 @@
+package graph
+
+// TODO
+// I want to work on a graph library for this, maybe rekindle kraph

--- a/pkg/oras/oras.go
+++ b/pkg/oras/oras.go
@@ -1,0 +1,111 @@
+package oras
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	oci "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/supercontainers/compspec-go/pkg/types"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/registry/remote"
+	"sigs.k8s.io/yaml"
+)
+
+// Oras will provide an interface to retrieve an artifact, specifically
+// a compatibillity spec artifact media type
+// LoadArtifact retrieves the artifact from the url string
+// and returns based on the media type
+func LoadArtifact(uri string, mediaType string) (types.CompatibilityRequest, error) {
+	request := types.CompatibilityRequest{}
+	ctx := context.Background()
+	repo, err := remote.NewRepository(uri)
+	if err != nil {
+		return request, err
+	}
+
+	// Disable plain http for now, assume using production registry
+	repo.PlainHTTP = false
+
+	// Split reference into tag, or assume latest
+	tag := "latest"
+	if strings.Contains(uri, ":") {
+		parts := strings.Split(uri, ":")
+		tag = parts[1]
+		uri = parts[0]
+	}
+
+	// Fetch manifest for the tag
+	desc, readCloser, err := repo.FetchReference(ctx, tag)
+	if err != nil {
+		return request, err
+	}
+	defer readCloser.Close()
+
+	// Read the pulled content
+	fmt.Printf("Found digest: %s for %s\n", desc.Digest.String(), tag)
+	manifestBytes, err := content.ReadAll(readCloser, desc)
+	if err != nil {
+		return request, err
+	}
+
+	// Going to be a big wild here and not check the mnaifest media type.
+	// We'd want to find oras, but no reason it can't be pushed another way...
+	// unmarshall it
+	var manifest oci.Manifest
+	err = json.Unmarshal(manifestBytes, &manifest)
+	if err != nil {
+		return request, err
+	}
+
+	// Loop through layers and find the media type we are looking for
+	for _, layer := range manifest.Layers {
+
+		// Skip layers that are not the compatibility spec... we seek
+		if layer.MediaType != mediaType {
+			continue
+		}
+
+		// Get the descriptor for the digest we want
+		desc, err := repo.Blobs().Resolve(ctx, string(layer.Digest))
+		if err != nil {
+			return request, err
+		}
+
+		// Download using the descriptor
+		readCloser, err := repo.Fetch(ctx, desc)
+		if err != nil {
+			return request, err
+		}
+		defer readCloser.Close()
+
+		// Read the descriptor into bytes
+		vr := content.NewVerifyReader(readCloser, desc)
+		buffer := bytes.NewBuffer(nil)
+		_, err = io.Copy(buffer, vr)
+		if err != nil {
+			return request, err
+		}
+
+		// note: users should not trust the the read content until Verify returns nil
+		if err := vr.Verify(); err != nil {
+			return request, err
+		}
+
+		// Convert this into our Compatibility Request
+		// reading from the buffer into bytes proper
+		readContent, err := io.ReadAll(buffer)
+		if err != nil {
+			return request, err
+		}
+
+		err = yaml.Unmarshal(readContent, &request)
+		if err != nil {
+			return request, err
+		}
+	}
+	return request, nil
+}

--- a/pkg/types/manifest.go
+++ b/pkg/types/manifest.go
@@ -1,0 +1,11 @@
+package types
+
+// A ManifestList is a manual definition of images and paired artifacts
+type ManifestList struct {
+	Images []ImagePair `json:"images"`
+}
+
+type ImagePair struct {
+	Name     string `json:"name"`
+	Artifact string `json:"artifact"`
+}


### PR DESCRIPTION
This update will allow reading in a manifest, which is a list of pairs of images and artifacts. Thanks to the media type of the artifact layer we can easily find the compatibility spec and then load it into the library. This is the core functionaltiy that we need to next create a graph to query over, and likely taking user preferences (a host to match to). While I could implement this very simply, I want to go down a bit of a rabbit hole and experiment with making a graph library/interface in go akin to kraft. Yeah, I kind of just want to have fun. ;)