### PR TITLE
Add start of parsing schemas and artifacts into graph

### DIFF
--- a/cmd/compspec/check/check.go
+++ b/cmd/compspec/check/check.go
@@ -1,9 +1,11 @@
 package check
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
+	"github.com/supercontainers/compspec-go/pkg/graph"
 	"github.com/supercontainers/compspec-go/pkg/oras"
 	"github.com/supercontainers/compspec-go/pkg/types"
 	"sigs.k8s.io/yaml"
@@ -47,17 +49,59 @@ func Run(manifestFile string, hostFields []string, mediaType string) error {
 	}
 	fmt.Println(manifestList)
 
+	// Prepare a graph with our compspec schemas added
+	g, err := graph.NewGraph()
+	if err != nil {
+		return err
+	}
+
 	// Load the compatibility specs into a lookup by image
 	// This assumes we allow one image per compability spec, not sure
 	// if there is a use case to have an image twice with two (sounds weird)
 	lookup := map[string]types.CompatibilityRequest{}
 	for _, item := range manifestList.Images {
+
 		compspec, err := oras.LoadArtifact(item.Artifact, mediaType)
 		if err != nil {
 			fmt.Printf("warning, there was an issue loading the artifact for %s, skipping\n", item.Name)
 		}
 		lookup[item.Name] = compspec
+
+		// Add schemas to the graph
+		for _, schema := range compspec.Metadata.Schemas {
+			fmt.Printf("Adding schema to graph %s\n", schema)
+			err = g.AddSchema(schema)
+			if err != nil {
+				return err
+			}
+		}
+
+		// When all schemas are added to a compatibility spec, we can walk graph to add metadata attributes
+		// Each compspec has a list of compatibilities
+		for _, compat := range compspec.Compatibilities {
+
+			// If we don't have the root node, no go
+			if !g.HasNode(compat.Name) {
+				return fmt.Errorf("Schema root node %s is missing from the graph, missing from schemas.", compat.Name)
+			}
+
+			// Now add each attribute. Each attribute turns into a child node of the attribute
+			// and if we are missing an attribute (meaning it isn't defined in the schema)
+			// that is an error! item.Name is the container image to link to each node
+			// in the traversal.
+			for key, value := range compat.Attributes {
+				err = g.AddAttribute(item.Name, compat.Name, key, value)
+			}
+		}
 	}
+	err = g.PrintMapping()
+	if err != nil {
+		return err
+	}
+
+	// Print the graph
+	printme, _ := json.MarshalIndent(g.Graph, "", "\t")
+	fmt.Println(string(printme))
 
 	// TODO we will take this set of requests, load them into a graph,
 	// and then query the graph based on user preferences (the host fields)

--- a/cmd/compspec/compspec.go
+++ b/cmd/compspec/compspec.go
@@ -6,10 +6,10 @@ import (
 	"os"
 
 	"github.com/akamensky/argparse"
-	"github.com/supercontainers/compspec-go/cmd/compspec/check"
 	"github.com/supercontainers/compspec-go/cmd/compspec/create"
 	"github.com/supercontainers/compspec-go/cmd/compspec/extract"
 	"github.com/supercontainers/compspec-go/cmd/compspec/list"
+	"github.com/supercontainers/compspec-go/cmd/compspec/match"
 	"github.com/supercontainers/compspec-go/pkg/types"
 )
 
@@ -33,7 +33,7 @@ func main() {
 	extractCmd := parser.NewCommand("extract", "Run one or more extractors")
 	listCmd := parser.NewCommand("list", "List plugins and known sections")
 	createCmd := parser.NewCommand("create", "Create a compatibility artifact for the current host according to a definition")
-	checkCmd := parser.NewCommand("check", "Check a manifest of container images / artifact pairs against a set of host fields")
+	matchCmd := parser.NewCommand("match", "Match a manifest of container images / artifact pairs against a set of host fields")
 
 	// Shared arguments (likely this will break into check and extract, shared for now)
 	pluginNames := parser.StringList("n", "name", &argparse.Options{Help: "One or more specific plugins to target names"})
@@ -41,12 +41,14 @@ func main() {
 	// Extract arguments
 	filename := extractCmd.String("o", "out", &argparse.Options{Help: "Save extraction to json file"})
 
-	// Check arguments
-	hostFields := checkCmd.StringList("a", "append", &argparse.Options{Help: "Append one or more host fields to include in the check"})
-	manifestFile := checkCmd.String("i", "in", &argparse.Options{Required: true, Help: "Input manifest list yaml that contains pairs of images and artifacts"})
+	// Match arguments
+	matchFields := matchCmd.StringList("m", "match", &argparse.Options{Help: "One or more key value pairs to match"})
+	manifestFile := matchCmd.String("i", "in", &argparse.Options{Required: true, Help: "Input manifest list yaml that contains pairs of images and artifacts"})
+	printMapping := matchCmd.Flag("p", "print", &argparse.Options{Help: "Print mapping of images to attributes only."})
+	printGraph := matchCmd.Flag("g", "print-graph", &argparse.Options{Help: "Print schema graph"})
 
 	// Create arguments
-	options := parser.StringList("a", "append", &argparse.Options{Help: "Append one or more custom metadata fields to append"})
+	options := createCmd.StringList("a", "append", &argparse.Options{Help: "Append one or more custom metadata fields to append"})
 	specname := createCmd.String("i", "in", &argparse.Options{Required: true, Help: "Input yaml that contains spec for creation"})
 	specfile := createCmd.String("o", "out", &argparse.Options{Help: "Save compatibility json artifact to this file"})
 	mediaType := createCmd.String("m", "media-type", &argparse.Options{Help: "The expected media-type for the compatibility artifact"})
@@ -69,8 +71,8 @@ func main() {
 		if err != nil {
 			log.Fatal(err.Error())
 		}
-	} else if checkCmd.Happened() {
-		err := check.Run(*manifestFile, *hostFields, *mediaType)
+	} else if matchCmd.Happened() {
+		err := match.Run(*manifestFile, *matchFields, *mediaType, *printMapping, *printGraph)
 		if err != nil {
 			log.Fatal(err.Error())
 		}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -92,7 +92,7 @@ The idea here is that you can add custom metadata fields during your build, whic
   "metadata": {
     "name": "lammps-prototype",
     "schemas": {
-      "archspec.io": "https://raw.githubusercontent.com/supercontainers/compspec/main/archspec/compspec.json",
+      "io.archspec": "https://raw.githubusercontent.com/supercontainers/compspec/main/archspec/compspec.json",
       "org.supercontainers": "https://raw.githubusercontent.com/supercontainers/compspec/main/supercontainers/compspec.json"
     }
   },
@@ -111,7 +111,7 @@ The idea here is that you can add custom metadata fields during your build, whic
       }
     },
     {
-      "name": "archspec.io",
+      "name": "io.archspec",
       "version": "0.0.0",
       "attributes": {
         "cpu.model": "13th Gen Intel(R) Core(TM) i5-1335U",
@@ -144,6 +144,8 @@ provide the parameters about the expected runtime host to them.
 ```bash
 ./bin/compspec check -i ./examples/check-lammps/manifest.yaml
 ```
+
+TODO stopped here, need to do the whole check thing.
 
 <details>
 

--- a/examples/check-lammps/README.md
+++ b/examples/check-lammps/README.md
@@ -27,17 +27,19 @@ first, generating the artifact and [pushing to oras](https://oras.land/docs/how_
 mkdir -p ./specs
 
 # arguments are the hasGpu command and the path for the artifact (relative to PWD)
+# TODO it looks like the arch is coming from my host, this would need to be run at build time alongside
+# the machine it was built on. We'd also want to make sure it's documented this is the case
 cmd=". /etc/profile && /tmp/data/generate-artifact.sh no /tmp/data/specs/compspec-intel-mpi-rocky-9-amd64.json"
 docker run -v $PWD:/tmp/data -it ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64 /bin/bash -c "$cmd"
 
 # This generates ./specs/compspec-intel-mpi-rocky-9-amd64.json, let's push to a registry with oras
-oras push ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64-compspec-test --artifact-type application/org.supercontainers.compspec ./specs/compspec-intel-mpi-rocky-9-amd64.json:application/org.supercontainers.compspec
+oras push ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64-compspec --artifact-type application/org.supercontainers.compspec ./specs/compspec-intel-mpi-rocky-9-amd64.json:application/org.supercontainers.compspec
 ```
 
 Here is how we might see it:
 
 ```bash
-oras blob fetch --output - ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64-compspec@sha256:b68136afad3e4340f0dd4e09c5fea7faf12306cb4b0c1de616703b00d6ffef78
+oras blob fetch --output - ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64-compspec@sha256:376ea8d492aa8e8db312cecc34bbc729d18fc2b30e891deb2ffdffa38c7db3a5
 ```
 ```console
 {
@@ -45,45 +47,36 @@ oras blob fetch --output - ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64
   "kind": "CompatibilitySpec",
   "metadata": {
     "name": "lammps-prototype",
-    "jsonSchema": "https://raw.githubusercontent.com/supercontainers/compspec/main/supercontainers/compspec.json"
+    "schemas": {
+      "io.archspec": "https://raw.githubusercontent.com/supercontainers/compspec/main/archspec/compspec.json",
+      "org.supercontainers": "https://raw.githubusercontent.com/supercontainers/compspec/main/supercontainers/compspec.json"
+    }
   },
   "compatibilities": [
     {
-      "name": "org.supercontainers.mpi",
+      "name": "org.supercontainers",
       "version": "0.0.0",
-      "annotations": {
-        "implementation": "intel-mpi",
-        "version": "2021.8"
+      "attributes": {
+        "hardware.gpu.available": "no",
+        "mpi.implementation": "intel-mpi",
+        "mpi.version": "2021.8",
+        "os.name": "Rocky Linux 9.3 (Blue Onyx)",
+        "os.release": "9.3",
+        "os.vendor": "rocky",
+        "os.version": "9.3"
       }
     },
     {
-      "name": "org.supercontainers.os",
+      "name": "io.archspec",
       "version": "0.0.0",
-      "annotations": {
-        "name": "Rocky Linux 9.3 (Blue Onyx)",
-        "release": "9.3",
-        "vendor": "rocky",
-        "version": "9.3"
-      }
-    },
-    {
-      "name": "org.supercontainers.hardware.gpu",
-      "version": "0.0.0",
-      "annotations": {
-        "available": "no"
-      }
-    },
-    {
-      "name": "io.archspec.cpu",
-      "version": "0.0.0",
-      "annotations": {
-        "model": "13th Gen Intel(R) Core(TM) i5-1335U",
-        "target": "amd64",
-        "vendor": "GenuineIntel"
+      "attributes": {
+        "cpu.model": "13th Gen Intel(R) Core(TM) i5-1335U",
+        "cpu.target": "amd64",
+        "cpu.vendor": "GenuineIntel"
       }
     }
   ]
 }
 ```
 
-This is great! Next we will capture the URIs of these together in a manifest and put into our compspec tool. TBA!
+This is great! Next we will capture the URIs of these together in a manifest and put into our compspec tool.

--- a/examples/check-lammps/README.md
+++ b/examples/check-lammps/README.md
@@ -79,4 +79,11 @@ oras blob fetch --output - ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64
 }
 ```
 
-This is great! Next we will capture the URIs of these together in a manifest and put into our compspec tool.
+Let's run a quick script that will generate this for a few images so we can better prototype our matching (check) command:
+
+```bash
+./extract.sh
+```
+
+Note that arch reflects our host environment, which is an issue we need to figure out. This
+also needs to be able to build for the right host arch. Next we will capture the URIs of these together in a manifest and put into our compspec tool.

--- a/examples/check-lammps/extract.sh
+++ b/examples/check-lammps/extract.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+mkdir -p ./specs
+
+# Pull images
+for image in $(cat ./images.txt); do
+    echo "Pulling ${image}"
+    docker pull $image
+
+    # Does it have gpu in the name?
+    echo $image | grep gpu
+    retval=$?
+    if [[ "$retval" -eq 0 ]]; then
+        echo "Image has GPU"
+        hasGpu=yes
+    else
+        echo "Image does not has GPU"
+        hasGpu=no
+    fi
+    tag=$(python -c "print('$image'.split(':')[-1])")
+    cmd=". /etc/profile && /tmp/data/install-and-generate.sh $hasGpu /tmp/data/specs/compspec-$tag.json"
+    echo "docker run --entrypoint /bin/bash -v $PWD:/tmp/data $image -c "$cmd""
+    docker run --entrypoint /bin/bash -v $PWD:/tmp/data $image -c "$cmd"
+
+    # This generates ./specs/compspec-intel-mpi-rocky-9-amd64.json, let's push to a registry with oras
+    oras push $image-compspec --artifact-type application/org.supercontainers.compspec ./specs/compspec-$tag.json:application/org.supercontainers.compspec
+done

--- a/examples/check-lammps/generate-artifact.sh
+++ b/examples/check-lammps/generate-artifact.sh
@@ -5,7 +5,7 @@ hasGpu="${1:-no}"
 path="${2:-./compatibility-spec.json}"
 
 # Note that this is hard coded for amd64, for arm you would wantt o add -arm or ppc64le -ppc
-wget --quiet https://github.com/supercontainers/compspec-go/releases/download/1-26-2024-2/compspec
+wget --quiet https://github.com/supercontainers/compspec-go/releases/download/2-2-2024-1/compspec
 chmod +x compspec
 
 # Download the spec for our compatibility artifact

--- a/examples/check-lammps/generate-artifact.sh
+++ b/examples/check-lammps/generate-artifact.sh
@@ -9,7 +9,7 @@ wget --quiet https://github.com/supercontainers/compspec-go/releases/download/2-
 chmod +x compspec
 
 # Download the spec for our compatibility artifact
-wget --quiet https://gist.githubusercontent.com/vsoch/fcd0f7d633860674cb085a8540ce4bb2/raw/4f8e730f1d74c070e63de79bf8b6f86a528ef1c9/lammps-experiment.yaml
+wget --quiet https://gist.githubusercontent.com/vsoch/fcd0f7d633860674cb085a8540ce4bb2/raw/6afeaad2f941414fdb744788643c8b3566c6c531/lammps-experiment.yaml
 
 # Generate!
 ./compspec create --in ./lammps-experiment.yaml -a custom.gpu.available=$hasGpu -o ${path}

--- a/examples/check-lammps/images.txt
+++ b/examples/check-lammps/images.txt
@@ -1,0 +1,4 @@
+ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64
+ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-8-amd64
+ghcr.io/rse-ops/lammps-matrix:openmpi-ubuntu-gpu-20.04
+ghcr.io/rse-ops/lammps-matrix:openmpi-ubuntu-gpu-22.04

--- a/examples/check-lammps/install-and-generate.sh
+++ b/examples/check-lammps/install-and-generate.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This assumes binding the entire directory with this script and lammps-experiment.yaml
+hasGpu="${1:-no}"
+path="${2:-./compatibility-spec.json}"
+# TODO need arm/ppc64le here
+
+# Compile compspec here so it's with the right glibc
+# assume we have wget and git for now
+# apt-get update && apt-get install -y wget git || yum update && yum install -y wget git
+wget https://go.dev/dl/go1.20.3.linux-amd64.tar.gz
+tar -xzf go1.20.3.linux-amd64.tar.gz  2>/dev/null
+mv go /usr/local && rm go1.20.3.linux-amd64.tar.gz    
+export PATH=$PATH:/usr/local/go/bin
+
+git clone -b add-start-of-check-graph https://github.com/supercontainers/compspec-go /tmp/cs
+cd /tmp/cs
+make
+export PATH=$PWD/bin:$PATH
+cd -
+
+# Download the spec for our compatibility artifact
+wget --quiet https://gist.githubusercontent.com/vsoch/fcd0f7d633860674cb085a8540ce4bb2/raw/02290df3aa3439caf9754d118a612906be3e3594/lammps-experiment.yaml
+
+# Generate!
+compspec create --in ./lammps-experiment.yaml -a custom.gpu.available=$hasGpu -o ${path}
+cat ${path}

--- a/examples/check-lammps/manifest.yaml
+++ b/examples/check-lammps/manifest.yaml
@@ -4,3 +4,9 @@
 images:
   - name: ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64
     artifact: ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64-compspec
+  - name: ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-8-amd64
+    artifact: ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-8-amd64-compspec
+  - name: ghcr.io/rse-ops/lammps-matrix:openmpi-ubuntu-gpu-20.04
+    artifact: ghcr.io/rse-ops/lammps-matrix:openmpi-ubuntu-gpu-20.04-compspec
+  - name: ghcr.io/rse-ops/lammps-matrix:openmpi-ubuntu-gpu-22.04
+    artifact: ghcr.io/rse-ops/lammps-matrix:openmpi-ubuntu-gpu-22.04-compspec

--- a/examples/check-lammps/specs/compspec-intel-mpi-rocky-8-amd64.json
+++ b/examples/check-lammps/specs/compspec-intel-mpi-rocky-8-amd64.json
@@ -1,0 +1,35 @@
+{
+  "version": "0.0.0",
+  "kind": "CompatibilitySpec",
+  "metadata": {
+    "name": "lammps-prototype",
+    "schemas": {
+      "io.archspec": "https://raw.githubusercontent.com/supercontainers/compspec/main/archspec/compspec.json",
+      "org.supercontainers": "https://raw.githubusercontent.com/supercontainers/compspec/main/supercontainers/compspec.json"
+    }
+  },
+  "compatibilities": [
+    {
+      "name": "org.supercontainers",
+      "version": "0.0.0",
+      "attributes": {
+        "hardware.gpu.available": "no",
+        "mpi.implementation": "intel-mpi",
+        "mpi.version": "2021.8",
+        "os.name": "Rocky Linux 8.9 (Green Obsidian)",
+        "os.release": "8.9",
+        "os.vendor": "rocky",
+        "os.version": "8.9"
+      }
+    },
+    {
+      "name": "io.archspec",
+      "version": "0.0.0",
+      "attributes": {
+        "cpu.model": "13th Gen Intel(R) Core(TM) i5-1335U",
+        "cpu.target": "amd64",
+        "cpu.vendor": "GenuineIntel"
+      }
+    }
+  ]
+}

--- a/examples/check-lammps/specs/compspec-intel-mpi-rocky-9-amd64.json
+++ b/examples/check-lammps/specs/compspec-intel-mpi-rocky-9-amd64.json
@@ -3,41 +3,32 @@
   "kind": "CompatibilitySpec",
   "metadata": {
     "name": "lammps-prototype",
-    "jsonSchema": "https://raw.githubusercontent.com/supercontainers/compspec/main/supercontainers/compspec.json"
+    "schemas": {
+      "io.archspec": "https://raw.githubusercontent.com/supercontainers/compspec/main/archspec/compspec.json",
+      "org.supercontainers": "https://raw.githubusercontent.com/supercontainers/compspec/main/supercontainers/compspec.json"
+    }
   },
   "compatibilities": [
     {
-      "name": "org.supercontainers.mpi",
+      "name": "org.supercontainers",
       "version": "0.0.0",
-      "annotations": {
-        "implementation": "intel-mpi",
-        "version": "2021.8"
+      "attributes": {
+        "hardware.gpu.available": "no",
+        "mpi.implementation": "intel-mpi",
+        "mpi.version": "2021.8",
+        "os.name": "Rocky Linux 9.3 (Blue Onyx)",
+        "os.release": "9.3",
+        "os.vendor": "rocky",
+        "os.version": "9.3"
       }
     },
     {
-      "name": "org.supercontainers.os",
+      "name": "io.archspec",
       "version": "0.0.0",
-      "annotations": {
-        "name": "Rocky Linux 9.3 (Blue Onyx)",
-        "release": "9.3",
-        "vendor": "rocky",
-        "version": "9.3"
-      }
-    },
-    {
-      "name": "org.supercontainers.hardware.gpu",
-      "version": "0.0.0",
-      "annotations": {
-        "available": "no"
-      }
-    },
-    {
-      "name": "io.archspec.cpu",
-      "version": "0.0.0",
-      "annotations": {
-        "model": "13th Gen Intel(R) Core(TM) i5-1335U",
-        "target": "amd64",
-        "vendor": "GenuineIntel"
+      "attributes": {
+        "cpu.model": "13th Gen Intel(R) Core(TM) i5-1335U",
+        "cpu.target": "amd64",
+        "cpu.vendor": "GenuineIntel"
       }
     }
   ]

--- a/examples/check-lammps/specs/compspec-openmpi-ubuntu-gpu-20.04.json
+++ b/examples/check-lammps/specs/compspec-openmpi-ubuntu-gpu-20.04.json
@@ -1,0 +1,35 @@
+{
+  "version": "0.0.0",
+  "kind": "CompatibilitySpec",
+  "metadata": {
+    "name": "lammps-prototype",
+    "schemas": {
+      "io.archspec": "https://raw.githubusercontent.com/supercontainers/compspec/main/archspec/compspec.json",
+      "org.supercontainers": "https://raw.githubusercontent.com/supercontainers/compspec/main/supercontainers/compspec.json"
+    }
+  },
+  "compatibilities": [
+    {
+      "name": "org.supercontainers",
+      "version": "0.0.0",
+      "attributes": {
+        "hardware.gpu.available": "yes",
+        "mpi.implementation": "OpenMPI",
+        "mpi.version": "4.0.3",
+        "os.name": "Ubuntu 20.04.6 LTS",
+        "os.release": "20.04.6",
+        "os.vendor": "ubuntu",
+        "os.version": "20.04"
+      }
+    },
+    {
+      "name": "io.archspec",
+      "version": "0.0.0",
+      "attributes": {
+        "cpu.model": "13th Gen Intel(R) Core(TM) i5-1335U",
+        "cpu.target": "amd64",
+        "cpu.vendor": "GenuineIntel"
+      }
+    }
+  ]
+}

--- a/examples/check-lammps/specs/compspec-openmpi-ubuntu-gpu-22.04.json
+++ b/examples/check-lammps/specs/compspec-openmpi-ubuntu-gpu-22.04.json
@@ -1,0 +1,35 @@
+{
+  "version": "0.0.0",
+  "kind": "CompatibilitySpec",
+  "metadata": {
+    "name": "lammps-prototype",
+    "schemas": {
+      "io.archspec": "https://raw.githubusercontent.com/supercontainers/compspec/main/archspec/compspec.json",
+      "org.supercontainers": "https://raw.githubusercontent.com/supercontainers/compspec/main/supercontainers/compspec.json"
+    }
+  },
+  "compatibilities": [
+    {
+      "name": "org.supercontainers",
+      "version": "0.0.0",
+      "attributes": {
+        "hardware.gpu.available": "yes",
+        "mpi.implementation": "OpenMPI",
+        "mpi.version": "4.1.2",
+        "os.name": "Ubuntu 22.04.3 LTS",
+        "os.release": "22.04.3",
+        "os.vendor": "ubuntu",
+        "os.version": "22.04"
+      }
+    },
+    {
+      "name": "io.archspec",
+      "version": "0.0.0",
+      "attributes": {
+        "cpu.model": "13th Gen Intel(R) Core(TM) i5-1335U",
+        "cpu.target": "amd64",
+        "cpu.vendor": "GenuineIntel"
+      }
+    }
+  ]
+}

--- a/examples/generated-compatibility-spec.json
+++ b/examples/generated-compatibility-spec.json
@@ -4,7 +4,7 @@
   "metadata": {
     "name": "lammps-prototype",
     "schemas": {
-      "archspec.io": "https://raw.githubusercontent.com/supercontainers/compspec/main/archspec/compspec.json",
+      "io.archspec": "https://raw.githubusercontent.com/supercontainers/compspec/main/archspec/compspec.json",
       "org.supercontainers": "https://raw.githubusercontent.com/supercontainers/compspec/main/supercontainers/compspec.json"
     }
   },
@@ -23,7 +23,7 @@
       }
     },
     {
-      "name": "archspec.io",
+      "name": "io.archspec",
       "version": "0.0.0",
       "attributes": {
         "cpu.model": "13th Gen Intel(R) Core(TM) i5-1335U",

--- a/examples/lammps-experiment.yaml
+++ b/examples/lammps-experiment.yaml
@@ -10,7 +10,7 @@ metadata:
   # "Validate the namespaced attributes with these schemas"
   schemas:
     org.supercontainers: https://raw.githubusercontent.com/supercontainers/compspec/main/supercontainers/compspec.json
-    archspec.io: https://raw.githubusercontent.com/supercontainers/compspec/main/archspec/compspec.json
+    io.archspec: https://raw.githubusercontent.com/supercontainers/compspec/main/archspec/compspec.json
 
 # These are not values, but mappings, from an extractor into the compspec we want
 compatibilities:
@@ -28,7 +28,7 @@ compatibilities:
 # Note that for now we are using the processor in index 0 to represent all
 # I'm not sure about cases where this set isn't homogeneous!
 # Since target is part of the container build, we will provide it
-- name: "archspec.io"
+- name: "io.archspec"
   version: "0.0.0"
   attributes:
     cpu.model: system.processor.0.model

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.5.3
 	github.com/moby/moby v25.0.0+incompatible
 	github.com/opencontainers/image-spec v1.1.0-rc5
+	github.com/scylladb/go-set v1.0.2
 	golang.org/x/sys v0.16.0
 	oras.land/oras-go/v2 v2.3.1
 	sigs.k8s.io/yaml v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/akamensky/argparse v1.4.0
 	github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8
+	github.com/converged-computing/jsongraph-go v0.0.0-20231221142916-249fef6889b3
 	github.com/jedib0t/go-pretty/v6 v6.5.3
 	github.com/moby/moby v25.0.0+incompatible
 	github.com/opencontainers/image-spec v1.1.0-rc5

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/converged-computing/jsongraph-go v0.0.0-20231221142916-249fef6889b3/g
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/set v0.2.1 h1:nn2CaJyknWE/6txyUDGwysr3G5QC6xWB/PtVjPBbeaA=
+github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/jedib0t/go-pretty/v6 v6.5.3 h1:GIXn6Er/anHTkVUoufs7ptEvxdD6KIhR7Axa2wYCPF0=
@@ -25,6 +27,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE=
+github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8 h1:SjZ2GvvOononHOpK
 github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8/go.mod h1:uEyr4WpAH4hio6LFriaPkL938XnrvLpNPmQHBdrmbIE=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
+github.com/converged-computing/jsongraph-go v0.0.0-20231221142916-249fef6889b3 h1:frJJfyARuHmF2eohDCyltBLE6tRJKvA1shuS2aWQaf8=
+github.com/converged-computing/jsongraph-go v0.0.0-20231221142916-249fef6889b3/go.mod h1:+DhVyLXGVfBsfta4185jd33jqa94inshCcdvsXK2Irk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/graph/edges.go
+++ b/pkg/graph/edges.go
@@ -1,0 +1,10 @@
+package graph
+
+import (
+	"github.com/converged-computing/jsongraph-go/jsongraph/v2/graph"
+)
+
+// Get an edge with a specific containment (typically "contains" or "in")
+func getEdge(source string, dest string, containment string) graph.Edge {
+	return graph.Edge{Source: source, Target: dest, Relation: containment}
+}

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -1,4 +1,221 @@
 package graph
 
-// TODO
-// I want to work on a graph library for this, maybe rekindle kraph
+import (
+	"fmt"
+	"strings"
+
+	"github.com/converged-computing/jsongraph-go/jsongraph/v2/graph"
+	jgf "github.com/converged-computing/jsongraph-go/jsongraph/v2/graph"
+	"github.com/supercontainers/compspec-go/pkg/utils"
+)
+
+const (
+	rootLabel = "compspec-root"
+)
+
+/*
+
+Desired steps:
+
+1. Load the schemas into a JSON Graph (called JGF).
+2. Do a depth first search until we find the first match
+3. Return the first match (greedy)
+
+*/
+
+type ImageMapping map[string]map[string]bool
+
+// addNs adds the namespace to a node or edge label
+func addNs(namespace, label string) string {
+	return fmt.Sprintf("%s.%s", namespace, label)
+}
+
+type CompatibilityGraph struct {
+	*jgf.JsonGraph
+
+	// Lookup of schemas we've added already
+	// This helps us ensure we add each only once
+	Schemas map[string]bool
+
+	// I did this strategy because the metadata elements of the JGF are a list
+	// This isn't ideal, but this will work for now. This is a lookup of node label
+	// to container images (strings). This might be better to use integers for
+	// larger graphs
+	Images ImageMapping `json:"imageMapping"`
+}
+
+// HasNode determines if the graph has a node, named by label
+func (c *CompatibilityGraph) HasNode(name string) bool {
+	_, ok := c.Graph.Nodes[name]
+	return ok
+}
+
+// AddAttribute adds an attribute to the graph, and a reference to
+// an image or application at each level.
+func (c *CompatibilityGraph) AddAttribute(
+	uri string,
+	schemaName string,
+	key string,
+	value string,
+) error {
+
+	// Create a reference for our container image / application if we don't have it yet
+	// I'm not sure which I'll need yet
+	images, ok := c.Images[uri]
+	if !ok {
+
+		// Flat lookup from container image URI to node labels
+		// where the application container is present
+		images = map[string]bool{}
+
+		// If this is the first time we've seen the image, add the root node
+		// This says that all images we map to the graph are at the root
+		// We only add the schema name given a feature below it is added (running this function)
+		images[rootLabel] = true
+		images[schemaName] = true
+	}
+
+	// Keep going until we hit the root
+	// This would parse like:
+	// hardware.gpu.available
+	// hardware.gpu
+	// hardware <- last node, parent is the schema node
+	notAtRoot := true
+	graphKey := key
+	for notAtRoot {
+
+		// Add the image identifier to the node
+		nsGraphKey := addNs(schemaName, graphKey)
+		images[nsGraphKey] = true
+
+		// When we hit a node that doesn't have a ., it's the root
+		// Note we use the graphKey to skip over the "." in the schema name
+		if strings.Contains(graphKey, ".") {
+
+			// Chop off last .<group> to the right
+			parts := strings.Split(graphKey, ".")
+			graphKey = strings.Join(parts[0:len(parts)-1], ".")
+
+		} else {
+
+			// If we are already at the last one, finish up
+			notAtRoot = false
+		}
+
+	}
+
+	// Final addition - we need to assign the image to the value
+	// The last nsGraphKey is the fullpath
+	nsValue := addNs(schemaName, fmt.Sprintf("%s.%s", key, value))
+	valueParent := addNs(schemaName, key)
+
+	// Create a node for the attribute, parent is the key
+	attrNode := newNode(nsValue)
+	edge := getEdge(valueParent, nsValue, "contains")
+	c.Graph.Edges = append(c.Graph.Edges, edge)
+	c.Graph.Nodes[nsValue] = *attrNode
+	images[nsValue] = true
+
+	// Update images for the uri
+	c.Images[uri] = images
+	return nil
+}
+
+// PrintMapping is a simple print function to show images and nodes mapped to
+func (c *CompatibilityGraph) PrintMapping() error {
+
+	fmt.Println(" -- Mapping for Images")
+	for image, nodes := range c.Images {
+		fmt.Printf("  image: %s\n", image)
+
+		// sort by key just so it is prettier
+		nodes := sortNodes(nodes)
+
+		fmt.Println("  nodes:")
+		for _, node := range nodes {
+			fmt.Printf("  -  %s\n", node)
+		}
+	}
+	return nil
+}
+
+// AddSchema by url to the graph
+func (c *CompatibilityGraph) AddSchema(url string) error {
+
+	// Have we added this schema before?
+	_, ok := c.Schemas[url]
+	if ok {
+		return nil
+	}
+	c.Schemas[url] = true
+
+	// Serialize the schema into JGF (it is version 2)
+	jgf := &graph.JsonGraph{}
+	err := utils.GetJsonUrl(url, jgf)
+	if err != nil {
+		return err
+	}
+
+	// Merge the graph, meaning we add it to our JsonGraph
+	// Likely we should have a merge function upstream
+	// This is the schema root node e.g, io.archspec
+	root := newNode(jgf.Graph.Id)
+	c.Graph.Nodes[jgf.Graph.Id] = *root
+
+	fmt.Printf("Schema %s is being added to the graph\n", jgf.Graph.Id)
+
+	// That needs to be added to the actual root
+	edge := getEdge(rootLabel, jgf.Graph.Id, "contains")
+	c.Graph.Edges = append(c.Graph.Edges, edge)
+
+	// Add each node from our schema graph
+	// If it's a top level node (no . to indicate nested)
+	// Add an edge to the top root
+	for nodeId, _ := range jgf.Graph.Nodes {
+
+		// The node needs to be namespaced by the schema
+		nsName := addNs(jgf.Graph.Id, nodeId)
+
+		// Create a new node. This strips metadata for now for a leaner graph
+		// this can be changed.
+		nsNode := newNode(nsName)
+
+		// Add the ids metadata for image ids
+		c.Graph.Nodes[nsName] = *nsNode
+
+		// This indicates a top level attribute in the schema namespace
+		// Note we are using the new namespaced name
+		if !strings.Contains(nodeId, ".") {
+			edge := getEdge(jgf.Graph.Id, nsName, "contains")
+			c.Graph.Edges = append(c.Graph.Edges, edge)
+		}
+	}
+
+	// Now add the remainder of edges (little subtrees!)
+	// We again need to add the namespace of the schema to avoid conflicts
+	for _, edge := range jgf.Graph.Edges {
+		source := addNs(jgf.Graph.Id, edge.Source)
+		target := addNs(jgf.Graph.Id, edge.Target)
+		edge := getEdge(source, target, "contains")
+		c.Graph.Edges = append(c.Graph.Edges, edge)
+	}
+	return nil
+}
+
+// Init a new FlexGraph from a graphml filename
+func NewGraph() (CompatibilityGraph, error) {
+
+	schemas := map[string]bool{}
+	images := map[string]map[string]bool{}
+
+	// prepare a graph to load targets into
+	g := jgf.NewGraph()
+
+	// An empty root off of which we will have schemas
+	root := newNode(rootLabel)
+	g.Graph.Nodes[rootLabel] = *root
+
+	// Return the compatibility graph wrapping it
+	cg := CompatibilityGraph{g, schemas, images}
+	return cg, nil
+}

--- a/pkg/graph/nodes.go
+++ b/pkg/graph/nodes.go
@@ -1,0 +1,31 @@
+package graph
+
+import (
+	"sort"
+
+	"github.com/converged-computing/jsongraph-go/jsongraph/metadata"
+	"github.com/converged-computing/jsongraph-go/jsongraph/v2/graph"
+)
+
+// newNode generates a new node with a lookup for image ids
+// This is unecessary, but added if this process is eventually more complex
+func newNode(label string) *graph.Node {
+
+	m := metadata.Metadata{}
+
+	// We will use this to map container image ids to each node
+	node := graph.Node{Label: &label, Metadata: m}
+	return &node
+
+}
+
+// sortNodes so they are pretty!
+func sortNodes(nodes map[string]bool) []string {
+
+	keys := make([]string, 0, len(nodes))
+	for node := range nodes {
+		keys = append(keys, node)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/utils/request.go
+++ b/pkg/utils/request.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// GetJsonUrl gets json from a url and decodes into target interface
+func GetJsonUrl(url string, target any) error {
+
+	cli := &http.Client{Timeout: 10 * time.Second}
+	r, err := cli.Get(url)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+	return json.NewDecoder(r.Body).Decode(target)
+}


### PR DESCRIPTION
This will generate the first schemas graph, and then prototype adding a single artifact (image reference and compatibility schema) onto it. Some design choices that I made are to store the mapping separate from the graph, that way we can always nuke them and start fresh without needing to recreate the graph. I also model a value (the leaf of the tree) as just another node, the idea being that we could extend the graph to include some new children. This sort of breaks the model that only the schemas should be nodes, but it is not so terrible an idea because in theory adding a value as a node on the fly could represent an updated cluster state (that is not present in the schema yet). THis might not be perfect but is a great start! I will next try to extract more of the artifacts and run this for a more reasonable image selection test case.