### PR TITLE
add support for cache and randomize

### DIFF
--- a/cmd/compspec/compspec.go
+++ b/cmd/compspec/compspec.go
@@ -49,6 +49,9 @@ func main() {
 	printGraph := matchCmd.Flag("g", "print-graph", &argparse.Options{Help: "Print schema graph"})
 	checkArtifacts := matchCmd.Flag("c", "check-artifacts", &argparse.Options{Help: "Check that all artifacts exist"})
 	allowFailMatch := matchCmd.Flag("f", "allow-fail", &argparse.Options{Help: "Allow an artifact to be missing (and not included)"})
+	randomize := matchCmd.Flag("r", "randomize", &argparse.Options{Help: "Shuffle match results in random order"})
+	single := matchCmd.Flag("s", "single", &argparse.Options{Help: "Only return a single result"})
+	cachePath := matchCmd.String("", "cache", &argparse.Options{Help: "A path to a cache for artifacts"})
 
 	// Create arguments
 	options := createCmd.StringList("a", "append", &argparse.Options{Help: "Append one or more custom metadata fields to append"})
@@ -76,11 +79,21 @@ func main() {
 			log.Fatal(err.Error())
 		}
 	} else if matchCmd.Happened() {
-		err := match.Run(*manifestFile, *matchFields, *mediaType, *printMapping, *printGraph, *allowFailMatch, *checkArtifacts)
+		err := match.Run(
+			*manifestFile,
+			*matchFields,
+			*mediaType,
+			*cachePath,
+			*printMapping,
+			*printGraph,
+			*allowFailMatch,
+			*checkArtifacts,
+			*randomize,
+			*single,
+		)
 		if err != nil {
 			log.Fatal(err.Error())
 		}
-
 	} else if listCmd.Happened() {
 		err := list.Run(*pluginNames)
 		if err != nil {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -204,6 +204,46 @@ ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-8-amd64
 
 That is very simple, but should serve our purposes for now.
 
+### Match with randomize or single
+
+You can choose to shuffle the results:
+
+```bash
+$ ./bin/compspec match -i ./examples/check-lammps/manifest.yaml --randomize
+```
+```console
+Schema io.archspec is being added to the graph
+Schema org.supercontainers is being added to the graph
+No field criteria provided, all images are matches.
+ --- Found matches ---
+ghcr.io/rse-ops/lammps-matrix:openmpi-ubuntu-gpu-20.04
+ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64
+ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-8-amd64
+ghcr.io/rse-ops/lammps-matrix:openmpi-ubuntu-gpu-22.04
+```
+Or do the same, but ask for only one result (note we might) change this to N results depending on use cases:
+
+```bash
+$ ./bin/compspec match -i ./examples/check-lammps/manifest.yaml --randomize --single
+```
+```console
+Schema io.archspec is being added to the graph
+Schema org.supercontainers is being added to the graph
+No field criteria provided, all images are matches.
+ --- Found matches ---
+ghcr.io/rse-ops/lammps-matrix:intel-mpi-rocky-9-amd64
+```
+
+### Match and use cache
+
+If you intend to run a match request many times (using repeated images) it's good practice to use a cache. This means you'll look in the cache before asking a registry, and save after if it doesn't exist. The directory must exist.
+
+```bash
+mkdir -p ./cache
+./bin/compspec match -i ./examples/check-lammps/manifest.yaml --cache ./cache
+```
+
+
 
 ### Match to print Metadata attributes
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,18 +4,19 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"math/rand"
 	"os"
 	"strings"
 )
 
-// FileExists determines if a file exists
-func FileExists(path string) (bool, error) {
+// PathExists determines if a path exists
+func PathExists(path string) (bool, error) {
 	_, err := os.Stat(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return false, nil
 		}
-		return true, fmt.Errorf("warning: file exists but another error happened (debug): %s", err)
+		return true, fmt.Errorf("warning: exists but another error happened (debug): %s", err)
 	}
 	return true, nil
 }
@@ -106,4 +107,13 @@ func ParseConfigFile(path, comment, delim string) (map[string]string, error) {
 		}
 	}
 	return data, nil
+}
+
+// RandomSort an array of strings, in place
+func RandomSort(items []string) []string {
+	for i := range items {
+		j := rand.Intn(i + 1)
+		items[i], items[j] = items[j], items[i]
+	}
+	return items
 }

--- a/plugins/extractors/system/arch.go
+++ b/plugins/extractors/system/arch.go
@@ -23,7 +23,7 @@ func getOsArch() (string, error) {
 
 	// Detect OS architecture based on presence of this file
 	for arch, path := range linkerPaths {
-		exists, err := utils.FileExists(path)
+		exists, err := utils.PathExists(path)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
If we are going to make many requests, it is good practice to cache the artifacts. This adds a parameter to do that, along with one to randomize results and return a single result