### PR TITLE
adding support to cache entire graph

### DIFF
--- a/cmd/compspec/compspec.go
+++ b/cmd/compspec/compspec.go
@@ -46,12 +46,13 @@ func main() {
 	matchFields := matchCmd.StringList("m", "match", &argparse.Options{Help: "One or more key value pairs to match"})
 	manifestFile := matchCmd.String("i", "in", &argparse.Options{Required: true, Help: "Input manifest list yaml that contains pairs of images and artifacts"})
 	printMapping := matchCmd.Flag("p", "print", &argparse.Options{Help: "Print mapping of images to attributes only."})
-	printGraph := matchCmd.Flag("g", "print-graph", &argparse.Options{Help: "Print schema graph"})
+	printGraph := matchCmd.Flag("", "print-graph", &argparse.Options{Help: "Print schema graph"})
 	checkArtifacts := matchCmd.Flag("c", "check-artifacts", &argparse.Options{Help: "Check that all artifacts exist"})
 	allowFailMatch := matchCmd.Flag("f", "allow-fail", &argparse.Options{Help: "Allow an artifact to be missing (and not included)"})
 	randomize := matchCmd.Flag("r", "randomize", &argparse.Options{Help: "Shuffle match results in random order"})
 	single := matchCmd.Flag("s", "single", &argparse.Options{Help: "Only return a single result"})
 	cachePath := matchCmd.String("", "cache", &argparse.Options{Help: "A path to a cache for artifacts"})
+	saveGraph := matchCmd.String("", "cache-graph", &argparse.Options{Help: "Load or use a cached graph"})
 
 	// Create arguments
 	options := createCmd.StringList("a", "append", &argparse.Options{Help: "Append one or more custom metadata fields to append"})
@@ -84,6 +85,7 @@ func main() {
 			*matchFields,
 			*mediaType,
 			*cachePath,
+			*saveGraph,
 			*printMapping,
 			*printGraph,
 			*allowFailMatch,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -243,7 +243,19 @@ mkdir -p ./cache
 ./bin/compspec match -i ./examples/check-lammps/manifest.yaml --cache ./cache
 ```
 
+You can also save the graph to file:
 
+```bash
+./bin/compspec match -i ./examples/check-lammps/manifest.yaml --cache ./cache --cache-graph ./cache/lammps-experiment.json
+```
+
+You can then use that cached graph later (NOTE this is at your own discretion knowing the schemas needed).
+
+```bash
+./bin/compspec match -i ./examples/check-lammps/manifest.yaml --cache ./cache --cache-graph ./cache/lammps-experiment.json
+```
+
+Likely we will make tools to visualize it that can just show JGF!
 
 ### Match to print Metadata attributes
 


### PR DESCRIPTION
with repeated calls, we should not need to derive it from source every time.

This will close #17 