### PR TITLE
fix: bug in containment name for node

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/akamensky/argparse v1.4.0
-	github.com/converged-computing/jsongraph-go v0.0.0-20240225004212-223ddffb7565
+	github.com/converged-computing/jsongraph-go v0.0.0-20240229082022-c6887a5a00fe
 	github.com/converged-computing/nfd-source v0.0.0-20240224025007-20d686e64926
 	github.com/jedib0t/go-pretty/v6 v6.5.4
 	github.com/moby/moby v25.0.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/akamensky/argparse v1.4.0 h1:YGzvsTqCvbEZhL8zZu2AiA5nq805NZh75JNj4ajn
 github.com/akamensky/argparse v1.4.0/go.mod h1:S5kwC7IuDcEr5VeXtGPRVZ5o/FdhcMlQz4IZQuw64xA=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
-github.com/converged-computing/jsongraph-go v0.0.0-20240225004212-223ddffb7565 h1:ZwJngPrF1yvM4ZGEyoT1b8h5e0qUumOxeDZLN37pPTk=
-github.com/converged-computing/jsongraph-go v0.0.0-20240225004212-223ddffb7565/go.mod h1:+DhVyLXGVfBsfta4185jd33jqa94inshCcdvsXK2Irk=
+github.com/converged-computing/jsongraph-go v0.0.0-20240229082022-c6887a5a00fe h1:Tk//RW3uKn4A7N8gpHRXs+ZGlR7Fxkwh+4/Iml0GBV4=
+github.com/converged-computing/jsongraph-go v0.0.0-20240229082022-c6887a5a00fe/go.mod h1:+DhVyLXGVfBsfta4185jd33jqa94inshCcdvsXK2Irk=
 github.com/converged-computing/nfd-source v0.0.0-20240224025007-20d686e64926 h1:VZmgK3t4564vdHNpE//q6kuPlugOrojkDHP4Gqd4A1g=
 github.com/converged-computing/nfd-source v0.0.0-20240224025007-20d686e64926/go.mod h1:I15nBsQqBTUsc3A4a6cuQmZjQ8lYUZSZ2a7UAE5SZ3g=
 github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=

--- a/pkg/graph/cluster.go
+++ b/pkg/graph/cluster.go
@@ -116,7 +116,7 @@ func (c *ClusterGraph) getNode(
 
 	// The resource name is the type + the resource counter
 	// path should be assembled from parents up to this node
-	resourceName := fmt.Sprintf("%s/%s%d", path, name, counter)
+	resourceName := fmt.Sprintf("%s/%s", path, nameWithCount)
 
 	// New Metadata with expected fluxion data
 	m := metadata.Metadata{}


### PR DESCRIPTION
Problem: there is a small bug that the node is using the uid (larger number) instead of the name.
Solution: get the name explicitly from the node to use.

Fixed gist is here - https://gist.github.com/vsoch/f9eb5e92f8c99bb00372b78ad978ac3b before it had node0, node1, node2 for the names, but then in the containment called them node0, node16, node32 (oops).